### PR TITLE
rollbar.js that export an instance of Rollbar class by default.

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 12,
   },
-  rules: {    
+  rules: {
     'linebreak-style': 'off',
   },
 };

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,25 +1,19 @@
 const express = require('express');
 const { config } = require('./config/config');
-const Rollbar = require('rollbar');
-const rollbar = new Rollbar({
-  accessToken: config.rollbarToken,
-  captureUncaught: true,
-  captureUnhandledRejections: true,
-  environment: config.environment,
-});
+const Rollbar = require('./lib/rollbar');
 // app
 const app = express();
 
-app.get('/', function (req, res) {
-  // rollbar.info('Awesome, this is a info log!');
+app.get('/', (req, res) => {
+  // Rollbar.log('Awesome, this is a info log!');
   res.send('Hola Mundo');
 });
 
 // this will send exception to rollbar account
-app.use(rollbar.errorHandler());
+app.use(Rollbar.errorHandler());
 
 // server
-const server = app.listen(config.port || 3000, function () {
+const server = app.listen(config.port || 3000, () => {
   // eslint-disable-next-line no-console
   console.log(`Listening http://localhost:${server.address().port}`);
 });

--- a/backend/lib/rollbar.js
+++ b/backend/lib/rollbar.js
@@ -1,0 +1,11 @@
+const Rollbar = require('rollbar');
+const { config } = require('../config/config');
+
+const rollbar = new Rollbar({
+  accessToken: config.rollbarToken,
+  captureUncaught: true,
+  captureUnhandledRejections: true,
+  environment: config.environment,
+});
+
+module.exports = rollbar;


### PR DESCRIPTION
Hola. Este PR lo que tiene es un modulo que exporta una instancia de la clase Rollbar.

Para que podamos sustituir los console.log() por Rollbar.log().

Para eso hay que importar el módulo que esta en lib/rollbar.js

**import Rollbar from "lib/rollbar"**

y después podemos usar:

**Rollbar.log('Awesome, this is a info log!');**

Saludos